### PR TITLE
feat: load favicon if configured via params.favicon

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -3,6 +3,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0"> <!-- This ensures your site looks right on mobile devices -->
     <link rel="stylesheet" type="text/css" href="/css/readable.css?v=1.0.1">
     <meta name="description" content='{{ .Page.Description }}'>
+    {{ if .Site.Params.favicon }}
+    <link rel="shortcut icon" href="{{ relURL ($.Site.Params.favicon) }}" type="image/x-icon" /> <!-- Show a favicon for your site, if one is configured in the Params section of the config. -->
+    {{ end }}
     {{ $title := print .Site.Title " | " .Title }}
     {{ if .IsHome }}{{ $title = .Site.Title }}{{ end }}
     <title>{{ $title }}</title>


### PR DESCRIPTION
This will display a favicon for the website. Favicons are cute little icons that will show up on tabs in your browser, e.g. GitHub's mascot. They can easily be generated by using online tools, e.g.

https://realfavicongenerator.net/

The resulting package only has to be downloaded and extracted into the 'static' directory of a Hugo website that is using this theme.

The path can then be set as follows in the config.yml:

```yaml
params:
  favicon: favicon.ico
```

This fixes #3.