### PR TITLE
fix: make tag links relative to the root of the page

### DIFF
--- a/layouts/partials/metadata.html
+++ b/layouts/partials/metadata.html
@@ -7,7 +7,7 @@
 {{ with .Params.tags }}
 <i data-feather="tag"></i>
 {{ range . }}
-{{ $href := print (absURL "tags/") (urlize .) }}
+{{ $href := print "/tags/" (urlize .) }}
 <a class="btn btn-sm btn-outline-dark tag-btn" href="{{ $href }}">{{ . }}</a>
 {{ end }}
 {{ end }}


### PR DESCRIPTION
Previously when we clicked on a tag link, it would append the path to where we currently were, e.g. clicking "tag" on a post in the `/posts/` lists, would send us to `/posts/tags/tag` instead of `/tags/tag`.

This fixes #7.