### PR TITLE
feat: add params.navbar_style to config to select a style for the navbar

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,10 +1,15 @@
 <h1>{{ $.Site.Title }}</h1>
 <p>{{ $.Site.Params.subtitle }}</p>
 
-<nav data-style="classy">
+<!-- readable.css v1.1.0 introduced different navbar styles and defaults to a
+navbar without animations. We default to "classy" to keep the animations and be
+backwards compatible to earlier versions of this theme without requiring a
+config change. -->
+{{ $navbar_style := (default "classy" $.Site.Params.navbar_style) }}
+<nav data-style={{ $navbar_style }}>
   {{ range .Site.Menus.main -}}
-  <span>
+  {{ if eq $navbar_style "classy" }}<span>{{ end }}
       <a href="{{ .URL | absLangURL }}">{{ .Name }}</a>
-  </span>
+  {{ if eq $navbar_style "classy" }}</span>{{ end }}
   {{- end }}
 </nav>


### PR DESCRIPTION
This is a new feature in readable.css 1.1.0. The new version of readable.css defaults to a navbar without animations, but to stay compatible with older releases of this theme, we default to "classy" instead which is the animated navbar.