### PR TITLE
CI: Add GitHub workflow to check for readable.css updates

### DIFF
--- a/.github/scripts/update-readable-css.sh
+++ b/.github/scripts/update-readable-css.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -o errexit
+set -o pipefail
+set -o nounset
+
+# Query the codeberg.org API (see
+# https://codeberg.org/api/swagger#/repository/repoListReleases) and use jq to
+# get the tag name of the latest release (i.e. the first element of the array
+# in the JSON output). Finally, use sed to remove the double quotes around the
+# value.
+TAG_VERSION=$(curl -s \
+    -H 'accept: application/json' \
+    https://codeberg.org/api/v1/repos/Freedom-to-Write/readable.css/releases \
+    | jq '.[0].tag_name' \
+    | sed 's/"//g')
+
+echo "Latest tag: ${TAG_VERSION}"
+
+# Get the current version.
+# The '-o' option will only output the match grep found.
+# We look for readable.min.css and a set of three numbers seperated by dots,
+# i.e. a semantic version. readable.min.css is used to make sure that we match
+# the right numbers in the file.
+# We use sed to get rid of the readable.min.css prefix.
+CURRENT_VERSION=$(grep -o \
+    'readable.min.css?v=[[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]\+' \
+    layouts/partials/head.html \
+    | sed 's/readable.min.css?v=/v/')
+echo "Current version: ${CURRENT_VERSION}"
+
+if [[ $TAG_VERSION == $CURRENT_VERSION ]]
+then
+    echo "Nothing to do. The current version is already up to date."
+else
+    curl -s "https://codeberg.org/Freedom-to-Write/readable.css/raw/tag/${TAG_VERSION}/readable.css" > static/css/readable.css
+    curl -s "https://codeberg.org/Freedom-to-Write/readable.css/raw/tag/${TAG_VERSION}/readable.min.css" > static/css/readable.min.css
+    VERSION=$(echo "${TAG_VERSION}" | sed 's/v//')
+    sed -i "s/readable.min.css?v=.*/readable.min.css?v=${VERSION}\">/" layouts/partials/head.html
+fi
+
+# Add the latest tag version to the workflow environment, so we can access
+# it in later steps.
+echo "READABLE_CSS_TAG=${TAG_VERSION}" >> "$GITHUB_ENV"

--- a/.github/workflows/update-readable-css.yml
+++ b/.github/workflows/update-readable-css.yml
@@ -1,0 +1,42 @@
+name: update-readable-css
+
+on:
+  schedule:
+    # Every day at 3:28.
+    - cron: '28 3 * * *'
+
+jobs:
+  update-readable-css:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Download CSS files for latest tag
+        run: .github/scripts/update-readable-css.sh
+      - name: Create pull request if files have changed
+        # https://github.com/marketplace/actions/create-pull-request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          # First line is the commit subject as always. The rest goes
+          # into the body.
+          commit-message: |
+            Update readable.css to ${{ env.READABLE_CSS_TAG }}
+
+            See the changelog here:
+
+            https://codeberg.org/Freedom-to-Write/readable.css/src/tag/${{ env.READABLE_CSS_TAG }}/CHANGELOG.md
+          branch: update-readable-css
+          delete-branch: true
+          # Use 'GitHub' both times.
+          # This is already the default for committer, but the author defaults
+          # to the user who triggered the workflow run, which is the owner of
+          # the repository.
+          # We use the same value for the author to indicate that the
+          # commit was created by a bot.
+          committer: GitHub <noreply@github.com>
+          author: GitHub <noreply@github.com>
+          title: Update readable.css to ${{ env.READABLE_CSS_TAG }}
+          body: |
+            See the changelog here:
+
+            https://codeberg.org/Freedom-to-Write/readable.css/src/tag/${{ env.READABLE_CSS_TAG }}/CHANGELOG.md
+          labels: update-readable-css


### PR DESCRIPTION
This adds a workflow and accompanying script to update readable.css. The script gets the latest tag version from the readable.css repository on codeberg.org and compares it to the currently used version. If the versions don't match up, we download readable.css and readable.min.css from Codeberg and update layouts/partials/head.html.

I initially didn't bother to check the current version, because ultimately we only do 3 requests against Codeberg every time the workflow executes. However, I'm expecting this workflow to run once a day currently. If someone were to increase the frequency significantly, this might become problematic for Codeberg. It's easy enough to optimize, so we should do it.

The workflow uses 'peter-evans/create-pull-request@v5', an action that allows us to create GitHub pull requests on the repo.

The action seems really thought through to me. I checked that an existing pull request is not duplicated. In case the 'main' branch changes in between, it will simply force push changes to the existing pull request. This also means that we won't get flooded with pull requests for the same version update.

If no changes are found, then the action will not open up a pull request at all.

The repository's settings need to be adjusted to allow workflows to create pull requests. This can be done in GitHub, by opening up the repository's 'Settings', clicking 'Actions' and 'General' and updating 'Workflow permissions' to allow 'Read and write permissions' and 'Allow GitHub Actions to create and approve pull requests'.

Other than that, there's nothing to do to enable this workflow. Once this commit is merged, the workflow will start it's scheduled execution.

The only thing I couldn't seem to get working is a notification for the newly created pull request. I'm not sure if I was simply unable to get it to work with a fork, or what's the reason behind this. I would have expected an email at least. However, I think this can be optimized in a future commit.