### PR TITLE
Add missing p tag in aside shortcode definition

### DIFF
--- a/layouts/shortcodes/aside.html
+++ b/layouts/shortcodes/aside.html
@@ -1,1 +1,1 @@
-<aside>{{ .Inner | markdownify }}</aside>
+<aside><p>{{ .Inner | markdownify }}</p></aside>


### PR DESCRIPTION
This fixes an issue where an `<aside>` element with a single line would look really weird and boxed in, compared to an `<aside>` element with multiple lines.

This has been bugging me for a while and I finally looked up how Benjamin Hollon handles this on his blog. Here's a good example:

https://benjaminhollon.com/musings/wireless-is-a-lie/

. When compared with my own blog, I noticed the additional `<p>` tag in Ben's code and everything became clear. If we have multiple lines, Hugo will automatically introduce paragraphs and the formatting will be correct. For a single line however, Hugo would assume that it was part of the content surrounding it. That's why the surrounding box of an `<aside>` element with a single line would look squashed.