### PR TITLE
Skip prereleases of readable.css in the CI workflow

### DIFF
--- a/.github/scripts/update-readable-css.sh
+++ b/.github/scripts/update-readable-css.sh
@@ -4,15 +4,22 @@ set -o pipefail
 set -o nounset
 
 # Query the codeberg.org API (see
-# https://codeberg.org/api/swagger#/repository/repoListReleases) and use jq to
-# get the tag name of the latest release (i.e. the first element of the array
-# in the JSON output). Finally, use sed to remove the double quotes around the
-# value.
+#   https://codeberg.org/api/swagger#/repository/repoListReleases
+# ) and use jq to get the tag name of the
+# latest release (i.e. the first element of the
+# array in the JSON output, that is not a
+# prerelease).
+# The '-r' option will give us "raw" output,
+# i.e. without surrounding double-quotes.
+# We use 'map' and 'select' in combination,
+# because jq won't return a list otherwise.
+# Only using 'select' returns just the matching
+# elements, which is not a valid json that we
+# can process further.
 TAG_VERSION=$(curl -s \
     -H 'accept: application/json' \
     https://codeberg.org/api/v1/repos/Freedom-to-Write/readable.css/releases \
-    | jq '.[0].tag_name' \
-    | sed 's/"//g')
+    | jq -r '.|map(select(.prerelease==false))[0].tag_name')
 
 echo "Latest tag: ${TAG_VERSION}"
 


### PR DESCRIPTION
Until now the algorithm would assume that the latest release on Codeberg is always a final release.

There is the very real possibility of prereleases, which we've learned today, but we can easily use jq to filter these out.

This relates to #19 and fixes #20.