### PR TITLE
Change Footer logic to account for .Site.Copyright and other methods

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,3 +1,8 @@
-<p><a href="/policies/privacy/">Privacy Policy</a> | <a href="/policies/cookies/">Cookie Policy</a> | <a href="/policies/terms/">Terms of Use</a></p> <!-- We like putting links in a paragraph separated by pipe ("|") characters -->
-<p>© 2023 {{ $.Site.Params.author }}</p> <!-- While not legally required, it's nice to put copyright and/or license info here. Also, it looks nice to break up the links with a line of text -->
+{{ if .Site.Params.footer.minimal | not }} 
+<p>
+	<a href="/policies/privacy/">Privacy Policy</a> | <a href="/policies/cookies/">Cookie Policy</a> | <a href="/policies/terms/">Terms of Use</a>
+	</p> 
+{{ end }}
+	<!-- We like putting links in a paragraph separated by pipe ("|") characters -->
+<p>{{ now.Format "2006" }} ©  {{ $.Site.Params.author }} {{ with .Site.Params.License }} - {{ . | markdownify }} {{ end }} </p> <!-- While not legally required, it's nice to put copyright and/or license info here. Also, it looks nice to break up the links with a line of text -->
 <a href={{ $.Site.Params.Mastodon }} rel="me" target="blank">Mastodon</a> | <a href="/contact/">Contact Me</a> | <a href="/posts/index.xml">RSS Feed</a></p> <!-- This is the kind of thing people look for in footers: contact info and legal info. Make sure you include both! -->

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -3,6 +3,10 @@
 	<a href="/policies/privacy/">Privacy Policy</a> | <a href="/policies/cookies/">Cookie Policy</a> | <a href="/policies/terms/">Terms of Use</a>
 	</p> 
 {{ end }}
-	<!-- We like putting links in a paragraph separated by pipe ("|") characters -->
-<p>{{ now.Format "2006" }} ©  {{ $.Site.Params.author }} {{ with .Site.Params.License }} - {{ . | markdownify }} {{ end }} </p> <!-- While not legally required, it's nice to put copyright and/or license info here. Also, it looks nice to break up the links with a line of text -->
+
+{{ with .Site.Copyright }}
+<p>{{ now.Format "2006" }} ©  {{ . | markdownify }}</p>
+{{ else }} 
+<p>{{ now.Format "2006" }} ©  {{ .Site.Params.author }} {{ with .Site.Params.License }} - {{ . | markdownify }} {{ end }} </p> <!-- While not legally required, it's nice to put copyright and/or license info here. Also, it looks nice to break up the links with a line of text -->
+{{ end }} 
 <a href={{ $.Site.Params.Mastodon }} rel="me" target="blank">Mastodon</a> | <a href="/contact/">Contact Me</a> | <a href="/posts/index.xml">RSS Feed</a></p> <!-- This is the kind of thing people look for in footers: contact info and legal info. Make sure you include both! -->


### PR DESCRIPTION
This works as follows:

It checks if .Site.Copyright is set (This is the standard way to set copyright in hugo, See documentation [here](https://gohugo.io/methods/site/copyright/) 

If that is not true, then fall back to the previous method of copyright, I have changed this from instead being a static year (using .now.Format "2006", to get the year during buildtime.

I have also added an additon which is the Parameter "License", this adds whatever the .License parameter is. 

I have also made an additional option, which is turned off by default, to conform to the initial way that this was built, which is the option inside the footer, which is "Minimal". I would however recommend changing the system we have here later on, as this does not allow easily adding extra personal stuff to the footer... 

Thank you for reading!

